### PR TITLE
Fix variable names in comment

### DIFF
--- a/Dict/beamformer_TimeDelay_2p3GHz.ipynb
+++ b/Dict/beamformer_TimeDelay_2p3GHz.ipynb
@@ -74,7 +74,7 @@
         "theta_target = 20  # deg\n",
         "true_delay_ps = d * np.sin(np.deg2rad(theta_target)) / c * 1e12\n",
         "\n",
-        "# Rx0 = 原始訊號；Rx1 = 延遲版（目標方向）\n",
+        "# Rx_0 = 原始訊號；Rx_1 = 延遲版（目標方向）\n",
         "def time_delayer(data, delay_time_ps, freq, samp_rate, do_phase_delay=True, do_time_delay=False):\n",
         "    delayed_data = data\n",
         "    if do_phase_delay:\n",


### PR DESCRIPTION
## Summary
- correct the comment above `time_delayer` so it references `Rx_0` and `Rx_1`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685523db94948326b6a25e8fc66fa7c3